### PR TITLE
Prettify JSONs with Jekyll-Tidy-JSON plugin

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ group :jekyll_plugins do
   gem "jekyll-asciimath", git: "https://github.com/riboseinc/jekyll-asciimath", ref: '9d2797e'
   gem "jekyll-sitemap"
   gem "jekyll-asciidoc"
+  gem "jekyll-tidy-json", "~> 1.2"
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -58,6 +58,8 @@ GEM
       jekyll (>= 3.7, < 5.0)
     jekyll-theme-isotc211-helpers (0.6.0)
       jekyll (~> 4.0)
+    jekyll-tidy-json (1.2.0)
+      jekyll (>= 3.8, < 5)
     jekyll-watch (2.2.1)
       listen (~> 3.0)
     kramdown (2.1.0)
@@ -95,6 +97,7 @@ DEPENDENCIES
   jekyll-plugin-frontend-build (~> 0.0.3)
   jekyll-sitemap
   jekyll-theme-isotc211-helpers (~> 0.6.0)
+  jekyll-tidy-json (~> 1.2)
   tzinfo-data
 
 BUNDLED WITH

--- a/_config.yml
+++ b/_config.yml
@@ -160,6 +160,10 @@ geolexica:
     - tbx-iso-tml
     - turtle
 
+tidy_json:
+  pretty: true
+  continue_on_error: true
+
 exclude:
   - iev-data/
   - README.adoc


### PR DESCRIPTION
A `continue_on_error` option must be enabled because `/api/concepts.json` is currently broken.