### PR TITLE
Use Concept#pages for pages lookup

### DIFF
--- a/_layouts/concept.html
+++ b/_layouts/concept.html
@@ -58,29 +58,29 @@ term_attributes:
   {% endif %}
 {% endfor %}
 
-{% assign json_concept = site.concepts_json | where: 'termid', page.termid | first %}
-{% assign json_url = json_concept.url %}
+
+{% assign json_url = page.representations.json.url %}
 <section class="field json">
   <p class="field-name">JSON</p>
   <p class="field-value"><a href="{{ json_url }}">{{ json_url }}</a></p>
 </section>
 
-{% assign json_concept = site.concepts_jsonld | where: 'termid', page.termid | first %}
-{% assign json_url = json_concept.url %}
+
+{% assign json_url = page.representations.jsonld.url %}
 <section class="field json">
   <p class="field-name">SKOS in JSON-LD</p>
   <p class="field-value"><a href="{{ json_url }}">{{ json_url }}</a></p>
 </section>
 
-{% assign ttl_concept = site.concepts_ttl | where: 'termid', page.termid | first %}
-{% assign ttl_url = ttl_concept.url %}
+
+{% assign ttl_url = page.representations.turtle.url %}
 <section class="field ttl">
   <p class="field-name">SKOS in RDF</p>
   <p class="field-value"><a href="{{ ttl_url }}">{{ ttl_url }}</a></p>
 </section>
 
-{% assign tbx_concept = site.concepts_tbx | where: 'termid', page.termid | first %}
-{% assign tbx_url = tbx_concept.url %}
+
+{% assign tbx_url = page.representations.tbx.url %}
 <section class="field tbx">
   <p class="field-name">TBX-ISO-TML</p>
   <p class="field-value"><a href="{{ tbx_url }}">{{ tbx_url }}</a></p>

--- a/_layouts/concept.tbx.xml.html
+++ b/_layouts/concept.tbx.xml.html
@@ -2,7 +2,7 @@
 layout: null
 ---
 {%- assign concept = page["eng"] -%}
-{%- assign concept_html = site.concepts | where: 'termid', page.termid | first -%}
+{%- assign concept_html = page.representations.html -%}
 {%- assign english = page["eng"] -%}
 <tbx type="TBX-Core" xmlns:tbx="urn:iso:std:iso:30042:ed-3">
 <tbx:termEntry id="{{ page.termid }}">

--- a/_layouts/concept.ttl.html
+++ b/_layouts/concept.ttl.html
@@ -3,7 +3,7 @@ layout: null
 ---
 {%- assign concept = page["eng"] -%}
 {%- assign rdfprofile = "/api/rdf-profile" -%}
-{%- assign concept_html = site.concepts | where: 'termid', page.termid | first -%}
+{%- assign concept_html = page.representations.html -%}
 {%- assign concept_id = concept_html.url -%}
 {%- assign english = page["eng"] -%}
 # baseURI: "{{ concept_id }}"


### PR DESCRIPTION
Speed up site building by using `Concept#pages` method instead of ridiculously slow Liquid `where` filter, as it is already done in upstream templates.