### PR TITLE
Delete unnecessary date from About page

### DIFF
--- a/_pages/about.adoc
+++ b/_pages/about.adoc
@@ -4,7 +4,6 @@ title: About
 permalink: /about/
 bodyClass: page
 nav_items: [concepts, posts,stats, feedback]
-show_header_meta: true
 ---
 :page-liquid:
 


### PR DESCRIPTION
Blog posts have dates, pages do not.  Fixes #24.