### PR TITLE
Display ISO 639 language codes in lower case

### DIFF
--- a/_includes/localized-concept.html
+++ b/_includes/localized-concept.html
@@ -2,7 +2,7 @@
   class="localized-term field lang-{{ lang }} status-{{ term_status }} classification-{{ classification }}"
   id="entry-lang-{{ lang }}">
 
-  <p class="field-name">{{ lang }}</p>
+  <p class="field-name field-name-language">{{ lang }}</p>
 
   <div class="field-value">
     {% for entry in localized_term.terms %}


### PR DESCRIPTION
Backport of https://github.com/geolexica/geolexica-server/pull/49.

Fixes #16.