### PR TITLE
Replace "escape" filter with "jsonify" in JSON-LDs

### DIFF
--- a/_source/_layouts/concept.jsonld.html
+++ b/_source/_layouts/concept.jsonld.html
@@ -24,7 +24,7 @@ layout: null
     {%- if term.normative_status == "preferred" or term.normative_status == "" -%}
     {
       "@language": "{{ site.data.lang[lang].iso-639-1 }}",
-      "@value": "{{ term.designation | escape | asciimath }}"
+      "@value": {{ term.designation | escape | asciimath | jsonify }}
     }{% unless forloop.last %},{% endunless %}
     {%- endif -%}
     {%- endfor -%}
@@ -38,7 +38,7 @@ layout: null
     {%- if term.normative_status == "admitted" -%}
     {
       "@language": "{{ site.data.lang[lang].iso-639-1 }}",
-      "@value": "{{ term.designation | escape | asciimath }}"
+      "@value": {{ term.designation | escape | asciimath | jsonify }}
     }{% unless forloop.last %},{% endunless %}
     {%- endif -%}
     {%- endfor -%}
@@ -51,7 +51,7 @@ layout: null
     {%- if localized_term.definition -%}
     {
       "@language": "{{ site.data.lang[lang].iso-639-1 }}",
-      "@value": "{{ localized_term.definition | escape | asciimath }}"
+      "@value": {{ localized_term.definition | escape | asciimath | jsonify }}
     }{% unless forloop.last %},{% endunless %}
     {%- endif -%}
     {%- endfor -%}
@@ -83,7 +83,7 @@ layout: null
           {%- if lang != "eng" and note == concept.notes[forloop.index0] -%}
           "@value": "notTranslated",
           {%- else -%}
-          "@value": "{{ note | escape | asciimath }}"
+          "@value": {{ note | escape | asciimath | jsonify }}
           {%- endif -%}
         }
       }{% unless forloop.last %},{% endunless %}
@@ -113,7 +113,7 @@ layout: null
           {%- if lang != "eng" and example == concept.examples[forloop.index0] -%}
           "@value": "notTranslated",
           {%- else -%}
-          "@value": "{{ example | escape | asciimath }}"
+          "@value": {{ example | escape | asciimath | jsonify }}
           {%- endif -%}
         }
       }{% unless forloop.last %},{% endunless %}
@@ -140,14 +140,14 @@ layout: null
   {%- assign term_status = concept.entry_status -%}
   {%- if concept.entry_status -%}
   "status": {
-    "@value": "{{ concept.entry_status | escape }}"
+    "@value": {{ concept.entry_status | jsonify }}
   },
   {%- endif -%}
 
   {%- assign classification = concept.classification -%}
   {%- if concept.classification -%}
   "classification": {
-    "@value": "{{ concept.classification | escape }}"
+    "@value": {{ concept.classification  | jsonify }}
   },
   {%- endif -%}
 


### PR DESCRIPTION
The `jsonify` filter does a much better job for various JSON files than `escape` filter, because it uses proper escape sequences.

Also, this reduces amount of differences between templates in this project and templates from Jekyll-Geolexica.