### PR TITLE
Change warning text

### DIFF
--- a/_source/_includes/localized-concept.html
+++ b/_source/_includes/localized-concept.html
@@ -37,7 +37,7 @@
       </p>
     {% endif %}
       <span class="warning">
-        This translated term may not be from the same source as the definitive term. Use at your own risk.
+        This translated term may not be from the same source as the normative term.
       </span>
     {% endif %}
 


### PR DESCRIPTION
Copy change which has been made in the Jekyll-Geolexica.

See:
- https://github.com/geolexica/geolexica-server/commit/1172d88336
- https://github.com/geolexica/geolexica-server/issues/101