### PR TITLE
Delete unused styles from AsciiMath gem

### DIFF
--- a/_source/_layouts/concept.html
+++ b/_source/_layouts/concept.html
@@ -2,8 +2,6 @@
 layout: default
 nav_items: [concepts, stats, about, posts, feedback]
 bodyClass: concept
-extra_stylesheets:
-  - href: "/assets/math.css"
 term_attributes:
   - definition
   - notes

--- a/_source/_layouts/domain.html
+++ b/_source/_layouts/domain.html
@@ -2,8 +2,6 @@
 layout: default
 nav_items: [home, about, stats, posts, feedback, registers]
 bodyClass: concepts
-extra_stylesheets:
-  - href: "/assets/math.css"
 ---
 <header>
   <p class="section-title">

--- a/_source/_pages/concepts.html
+++ b/_source/_pages/concepts.html
@@ -4,8 +4,6 @@ permalink: "/concepts/index.html"
 nav_items: [home, about, stats, posts, feedback, registers]
 bodyClass: concepts
 title: All Concepts
-extra_stylesheets:
-  - href: "/assets/math.css"
 ---
 <header>
   <h1>All Concepts</h1>


### PR DESCRIPTION
The `math.css` stylesheet is provided by AsciiMath gem, and has been added to HTMLs in 5905c79 as it is required to display HTML math properly (HTML math is a way of presenting mathematical formulas with regular HTML elements and CSS).  We have switched to MathML since then, and this stylesheet is no longer used.