### PR TITLE
Enable MathJax on this site

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -154,6 +154,7 @@ defaults:
 geolexica:
   concepts_glob: "../iev-data/concepts/concept-*.yaml"
   concept_date_format: "%Y-%m"
+  math: true
   term_languages:
     - eng
     - fra

--- a/_source/_layouts/default.html
+++ b/_source/_layouts/default.html
@@ -155,6 +155,10 @@
 
     {% include script.html %}
 
+    {% if site.geolexica.math %}
+      {%- include math-config.html -%}
+    {% endif %}
+
     <template id="expandableNavTrigger">
       <button class="nav-expand-trigger">
         <i class="fas fa-bars"></i>


### PR DESCRIPTION
Since geolexica/geolexica-server#110, Jekyll-Geolexica has an opt-in support for [MathJax](https://www.mathjax.org/) library, which we want to have on all the math-enabled sites (see: https://github.com/geolexica/geolexica-server/issues/109).