### PR TITLE
Specify site branding in _config.yml, and delete some template differences

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source "https://rubygems.org"
 
-gem "geolexica-site", "1.5.0"
+gem "geolexica-site", "1.5.1"
 
 gem "jekyll-asciimath", "~> 1.1.0"

--- a/_config.yml
+++ b/_config.yml
@@ -5,7 +5,13 @@ title: "IEV Electropedia Glossarist demo"
 google_analytics:
   id: UA-169198783-1
 
-logo_path: assets/images/IEC_logo.svg
+committee:
+  main_logo:
+    path: assets/images/IEC_logo.svg
+  footer_logo:
+    path: assets/images/IEC_logo.svg
+    url: https://www.iec.ch/
+
 font_awesome_kit_url: https://kit.fontawesome.com/77a8a07e0a.js
 
 # This is to convert jekyll-asciidoc math into real MathML

--- a/_source/_includes/committee-widget.html
+++ b/_source/_includes/committee-widget.html
@@ -1,0 +1,5 @@
+{% comment %}
+
+The template is empty, because there shouldn't be such widget on this site.
+
+{% endcomment %}

--- a/_source/_layouts/default.html
+++ b/_source/_layouts/default.html
@@ -18,6 +18,8 @@
         </div>
 
         <div class="site-title">
+          {% include committee-widget.html %}
+
           <h1 class="title">
             <a href="/">{{ site.title_html | default: site.title }}</a>
           </h1>

--- a/_source/_layouts/default.html
+++ b/_source/_layouts/default.html
@@ -18,53 +18,6 @@
         </div>
 
         <div class="site-title">
-          {% if site.committee %}
-            <span class="committee-widget">
-              <span class="widget-group">
-                {%- if site.committee.parent_org_name %}
-                <span class="widget-item parent-org-reference">
-                  {{ site.committee.parent_org_name }}
-                </span>
-                {%- endif %}
-                {%- if site.committee.identifier %}
-                <span class="widget-item committee-id">
-                  {{ site.committee.identifier }}
-                </span>
-                {%- endif %}
-                {%- if site.committee.name %}
-                <span class="widget-item committee-name">
-                  {{ site.committee.name }}
-                </span>
-                {%- endif %}
-
-                {% if page.layout == "home" and site.always_show_committee_link_on_landing and site.committee.home %}
-                  <a href="{{ site.committee.home }}" class="widget-item home">
-                    <i class="fas fa-home"></i>
-                    Committee site
-                  </a>
-                {% endif %}
-              </span>
-            {% endif %}
-
-            {% if site.committee.home or site.committee.links %}
-              <span class="widget-group committee-menu">
-                {% unless page.layout == "home" and site.always_show_committee_link_on_landing and site.committee.home %}
-                  <a href="{{ site.committee.home }}" class="widget-item home">
-                    <i class="fas fa-home"></i>
-                    Committee site
-                  </a>
-                {% endunless %}
-                {% if site.committee.links %}
-                  {% for link in site.committee.links %}
-                    <a href="{{ link.url }}" class="widget-item">
-                      {{ link.title }}
-                    </a>
-                  {% endfor %}
-                {% endif %}
-              </span>
-            {% endif %}
-          </span>
-
           <h1 class="title">
             <a href="/">{{ site.title_html | default: site.title }}</a>
           </h1>

--- a/_source/_layouts/default.html
+++ b/_source/_layouts/default.html
@@ -13,7 +13,7 @@
       <div class="site-headline">
         <div class="parent-org-reference">
           <a href="/" class="logo-link">
-            <img src="{{ site.committee.main_logo.path | default: site.logo_path | relative_url }}" alt="{{ site.committee.main_logo.alt_text }}">
+            <img src="{{ site.committee.main_logo.path | relative_url }}" alt="{{ site.committee.main_logo.alt_text }}">
           </a>
         </div>
 
@@ -104,7 +104,7 @@
       </p>
 
       <div class="logo">
-        <a href="{{ site.committee.footer_logo.url | default: site.org.website.url }}"><img src="{{ site.committee.footer_logo.path | default: site.logo_path | relative_url }}" alt="{{ site.committee.footer_logo.alt_text }}"/></a>
+        <a href="{{ site.committee.footer_logo.url }}"><img src="{{ site.committee.footer_logo.path | relative_url }}" alt="{{ site.committee.footer_logo.alt_text }}"/></a>
       </div>
     </footer>
 


### PR DESCRIPTION
The "committee" configuration entry is the intended place to set up site branding.  Doing that the other way has introduced some completely unnecessary differences between templates in this project and in Jekyll-Geolexica. Now these differences are being removed.

As a side effect, it also removes outstanding `</span>` tag from HTML output.